### PR TITLE
Add options to disable various enabled-by-default porman features

### DIFF
--- a/docs/Fileformat.md
+++ b/docs/Fileformat.md
@@ -93,10 +93,24 @@ Supported keys in `Container` group are:
   this differs from the gid in `Group` then user namespaces are used
   to map the ids. If unspecified this defaults to what was specified in `Group`.
 
+* `NoNewPrivileges=` (defaults to `yes`)
+
+  If enabled (which is the default) this disables the container
+  processes from gaining additional privileges via things like
+  setuid and file capabilieities.
+
+* `DropCapability=` (defaults to `all`)
+
+   Drop these capabilities from the default container capability set.
+   The default is `all`, so you have to add any capabilities you want
+   with `AddCapability`. Set this to empty to drop no capabilities.
+   This can be listed multiple times.
+
 * `AddCapability=`
 
-   By default the container runs with no capabilities, if any are
-   needed you can list add them with this key. For example using
+   By default the container runs with no capabilities (due to
+   DropCapabilities='all'), if any specific caps are needed you can
+   list add them with this key. For example using
    `AddCapability=CAP_DAC_OVERRIDE`. This can be listed multiple
    times.
 
@@ -154,6 +168,20 @@ Supported keys in `Container` group are:
    If this is true, then the file descriptors and environment variables for socket activation
    is passed to the container. This is only needed for older versions of podman, since podman
    was [recently made to handle this automatically](https://github.com/containers/podman/pull/11316).
+
+* `Timezone=` (default to `local`)
+
+   The timezone to run the container in.
+
+* `RunInit=` (default to `yes`)
+
+   If enabled (and it is by default), the container will have a
+   minimal init process inside the container that forwards signals and
+   reaps processes.
+
+* `VolatileTmp=` (default to `yes`)
+
+   If enabled (and it is by default), the container will have a fresh tmpfs mounted on `/tmp`.
 
 * `Volume=`
 

--- a/src/unitfile.c
+++ b/src/unitfile.c
@@ -617,6 +617,14 @@ quad_unit_file_lookup_last_raw (QuadUnitFile *self,
   return NULL;
 }
 
+gboolean
+quad_unit_file_has_key (QuadUnitFile  *self,
+                        const char    *group_name,
+                        const char    *key)
+{
+  return quad_unit_file_lookup_last_raw (self, group_name, key) != NULL;
+}
+
 char *
 quad_unit_file_lookup_last (QuadUnitFile  *self,
                             const char    *group_name,

--- a/src/unitfile.h
+++ b/src/unitfile.h
@@ -26,6 +26,9 @@ void          quad_unit_file_set_path        (QuadUnitFile  *self,
                                               const char    *path);
 void          quad_unit_file_print           (QuadUnitFile  *self,
                                               GString       *str);
+gboolean      quad_unit_file_has_key         (QuadUnitFile  *self,
+                                              const char    *group_name,
+                                              const char    *key);
 const char *  quad_unit_file_lookup_last_raw (QuadUnitFile  *self,
                                               const char    *group_name,
                                               const char    *key);

--- a/tests/cases/basepodman.container
+++ b/tests/cases/basepodman.container
@@ -1,0 +1,12 @@
+## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm -d --log-driver journald --pull=never --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon imagename
+
+[Container]
+Image=imagename
+
+# Disable all default features to get as empty podman run command as we can
+RemapUsers=no
+NoNewPrivileges=no
+DropCapability=
+RunInit=no
+VolatileTmp=no
+Timezone=


### PR DESCRIPTION
This adds support for: `NoNewPrivileges`, "DropCapability`, `RunInit`,`VolatileTmp` `Timezone`. With the default being they are enabled as before, but now you can disable them.

There is also a new testcase `basepodman.container` that tests disabling most podman run options.
