### PR TITLE
Default to system-configured timezone instead of `local`

### DIFF
--- a/docs/ContainerSetup.md
+++ b/docs/ContainerSetup.md
@@ -172,13 +172,6 @@ Here are some things that are set up:
   This makes /tmp in the container be a tmpfs, similar to how it is set
   up on the host. This can be overridden with `VolatileTmp=no`.
 
-* `--tz=local`
-
-  This sets the timezone of the container to match whatever the host OS
-  uses. For distributed host-isolated services it makes sense to always
-  run in UTC, but for a system service we want to be as close as
-  possible to the host. This can be overridden with `Timnezone=`.
-
 * `--pull=never`
 
   Never pull the image during service start. If the image is missing this

--- a/src/generator.c
+++ b/src/generator.c
@@ -308,10 +308,7 @@ convert_container (QuadUnitFile *container, GError **error)
                     NULL);
 
   g_autofree char *timezone =  quad_unit_file_lookup (container, CONTAINER_GROUP, "Timezone");
-  /* Use the host timezone by default*/
-  if (timezone == NULL)
-    timezone = g_strdup ("local");
-  if (*timezone != 0)
+  if (timezone != NULL && *timezone != 0)
     quad_podman_addf (podman, "--tz=%s", timezone);
 
   /* Run with a pid1 init to reap zombies by default (as most apps don't do that) */

--- a/tests/cases/basic.container
+++ b/tests/cases/basic.container
@@ -7,7 +7,6 @@
 ## assert-podman-args "--log-driver" "journald"
 ## assert-podman-args "--pull=never"
 ## assert-podman-args "--init"
-## assert-podman-args "--tz=local"
 ## assert-podman-args "--runtime" "/usr/bin/crun"
 ## assert-podman-args "--cgroups=split"
 ## assert-podman-args "--sdnotify=conmon"


### PR DESCRIPTION
I've run into issues on systems that don't have a local timezone configured
where the container wouldn't start. I don't think timezones are that important
for servicese anyway, so lets drop this default change (typically now we
get UTC tz containers).