### PR TITLE
Replace KeepUser with KeepId in supported_container_keys

### DIFF
--- a/src/generator.c
+++ b/src/generator.c
@@ -33,7 +33,7 @@ static const char *supported_container_keys[] = {
   "SocketActivated",
   "ExposeHostPort",
   "PublishPort",
-  "KeepUser",
+  "KeepId",
   "User",
   "Group",
   "HostUser",


### PR DESCRIPTION
The rest of the code and the doc use KeepId but the list of supported container keys contained KeepUser.