### PR TITLE
Add support for ContainerName

### DIFF
--- a/docs/Fileformat.md
+++ b/docs/Fileformat.md
@@ -83,6 +83,13 @@ Supported keys in `Container` group are:
    because the generated service file will never try to download
    images.
 
+* `ContainerName=`
+
+   The (optional) name of the podman container. If this is not
+   specified, the default value of `systemd-%N` will be used,
+   which is the same as the service name but with a `systemd-`
+   prefix to avoid conflicts with user-managed containers.
+
 * `Environment=`
 
   Set an environment variable in the container. This uses the same

--- a/src/generator.c
+++ b/src/generator.c
@@ -272,9 +272,9 @@ convert_container (QuadUnitFile *container, GError **error)
   quad_unit_file_add (service, SERVICE_GROUP,
                       "ExecStopPost", "-rm -f %t/%N.cid");
 
-  g_autoptr(QuadPodman) podman = quad_podman_new ();
+  g_autoptr(QuadPodman) podman = quad_podman_new ("run", NULL);
 
-  quad_podman_addv (podman, "run",
+  quad_podman_addv (podman,
 
                     /* We want to name the container by the service name */
                     "--name=systemd-%N",
@@ -634,9 +634,7 @@ convert_volume (QuadUnitFile *container,
   g_auto(GStrv) labels = quad_unit_file_lookup_all (container, VOLUME_GROUP, "Label");
   g_autoptr(GHashTable) podman_labels = parse_keys (labels);
 
-  g_autoptr(QuadPodman) podman = quad_podman_new ();
-  quad_podman_addv (podman,
-                    "volume", "create", NULL);
+  g_autoptr(QuadPodman) podman = quad_podman_new ("volume", "create");
 
   g_autoptr(GString) opts = g_string_new ("o=");
 

--- a/src/podman.c
+++ b/src/podman.c
@@ -7,12 +7,19 @@ struct QuadPodman {
   GPtrArray *args;
 };
 
-QuadPodman *quad_podman_new (void)
+QuadPodman *quad_podman_new (const char *command, const char *sub_command)
 {
   QuadPodman *podman = g_new0 (QuadPodman, 1);
 
   podman->args = g_ptr_array_new_with_free_func (g_free);
   quad_podman_add (podman, "/usr/bin/podman");
+
+  if (command)
+    quad_podman_add (podman, command);
+
+  if (sub_command)
+    quad_podman_add (podman, sub_command);
+
   return podman;
 }
 

--- a/src/podman.h
+++ b/src/podman.h
@@ -6,7 +6,8 @@ G_BEGIN_DECLS
 
 typedef struct QuadPodman QuadPodman;
 
-QuadPodman *quad_podman_new (void);
+QuadPodman *quad_podman_new (const char *command,
+                             const char *sub_command);
 void        quad_podman_free (QuadPodman *podman);
 void        quad_podman_add (QuadPodman *podman,
                              const char *arg);

--- a/tests/cases/name.container
+++ b/tests/cases/name.container
@@ -1,0 +1,5 @@
+## assert-podman-args "--name=foobar"
+
+[Container]
+Image=imagename
+ContainerName=foobar


### PR DESCRIPTION
This allows you to set a custom name for the podman container, in case you e.g. don't want the `systemd-` prefix.

Fixes #31
