### PR TITLE
Some behaviour changes in preparation for podman merge

### DIFF
--- a/docs/Fileformat.md
+++ b/docs/Fileformat.md
@@ -152,7 +152,7 @@ Supported keys in `Container` group are:
    `AddCapability=CAP_DAC_OVERRIDE`. This can be listed multiple
    times.
 
-* `RemapUsers=` (defaults to `yes` for system units, always `no` on user units)
+* `RemapUsers=` (defaults to `no`)
 
    If this is enabled (which is the default for system units), then
    host user and group ids are remapped in the container, such that

--- a/docs/Fileformat.md
+++ b/docs/Fileformat.md
@@ -152,6 +152,11 @@ Supported keys in `Container` group are:
    `AddCapability=CAP_DAC_OVERRIDE`. This can be listed multiple
    times.
 
+* `ReadOnly=` (defaults to `no`)
+
+   If enabled, makes image read-only, with /var/tmp, /tmp and /run
+   a tmpfs (unless disabled by `VolatileTmp=no`).
+
 * `RemapUsers=` (defaults to `no`)
 
    If this is enabled (which is the default for system units), then

--- a/docs/Fileformat.md
+++ b/docs/Fileformat.md
@@ -217,7 +217,7 @@ Supported keys in `Container` group are:
    is passed to the container. This is only needed for older versions of podman, since podman
    was [recently made to handle this automatically](https://github.com/containers/podman/pull/11316).
 
-* `Timezone=` (default to `local`)
+* `Timezone=` (if unset uses system-configured default)
 
    The timezone to run the container in.
 

--- a/src/generator.c
+++ b/src/generator.c
@@ -422,7 +422,7 @@ convert_container (QuadUnitFile *container, GError **error)
         quad_podman_addf (podman, "%lu:%lu", (long unsigned)uid, (long unsigned)gid);
     }
 
-  gboolean remap_users = quad_unit_file_lookup_boolean (container, CONTAINER_GROUP, "RemapUsers", TRUE);
+  gboolean remap_users = quad_unit_file_lookup_boolean (container, CONTAINER_GROUP, "RemapUsers", FALSE);
 
   if (quad_is_user)
     remap_users = FALSE;

--- a/tests/cases/basic.container
+++ b/tests/cases/basic.container
@@ -12,7 +12,7 @@
 ## assert-podman-args "--sdnotify=conmon"
 ## assert-podman-args "--security-opt=no-new-privileges"
 ## assert-podman-args "--cap-drop=all"
-## assert-podman-args "--mount" "type=tmpfs,tmpfs-size=512M,destination=/tmp"
+## assert-podman-args "--tmpfs" "/tmp:rw,size=512M,mode=1777"
 ## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
 ## assert-key-is "Service" "KillMode" "mixed"
 ## assert-key-is "Service" "Delegate" "yes"

--- a/tests/cases/user-host.container
+++ b/tests/cases/user-host.container
@@ -17,6 +17,8 @@ HostUser=900
 Group=1001
 HostGroup=901
 
+RemapUsers=yes
+
 # Set this to get well-known valuse for the checks
 RemapUidRanges=100000-199999
 RemapGidRanges=100000-199999

--- a/tests/cases/user-root1.container
+++ b/tests/cases/user-root1.container
@@ -20,6 +20,7 @@ User=1000
 HostUser=root
 Group=1001
 HostGroup=0
+RemapUsers=yes
 # Set this to get well-known valuse for the checks
 RemapUidRanges=100000-199999
 RemapGidRanges=100000-199999

--- a/tests/cases/user-root2.container
+++ b/tests/cases/user-root2.container
@@ -16,6 +16,7 @@ User=0
 HostUser=root
 Group=0
 HostGroup=0
+RemapUsers=yes
 # Set this to get well-known valuse for the checks
 RemapUidRanges=100000-199999
 RemapGidRanges=100000-199999


### PR DESCRIPTION
This changes the default to not remap users (had a lot of issues with that), and adds support for --readonly.